### PR TITLE
クエリの発行数改善

### DIFF
--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -67,7 +67,7 @@ class AttendancesController < ApplicationController
 
     def set_date_and_attendances
       @date = Date.parse(params[:date])
-      @attendances = Attendance.where(date: @date).order(:id)
+      @attendances = Attendance.includes(:workers, :vehicles).where(date: @date)
     end
 
     def failed_attendances(attendances)

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -67,7 +67,7 @@ class AttendancesController < ApplicationController
 
     def set_date_and_attendances
       @date = Date.parse(params[:date])
-      @attendances = Attendance.includes(:workers, :vehicles).where(date: @date)
+      @attendances = Attendance.where(date: @date).order(:id)
     end
 
     def failed_attendances(attendances)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,8 +1,9 @@
 module ApplicationHelper
-  def header_link(label, path, icon, condition = nil, options = {}, link_class = "link-dark")
-    unless condition
+  def header_link(options = {})
+    unless options[:condition]
       content_tag :li do
-        link_to label, path, options.merge({ class: "fas #{icon} text-decoration-none #{link_class}" })
+        link_to options[:label], options[:path],
+                options[:link_options].merge({ class: "fas #{options[:icon]} text-decoration-none #{options[:link_class]}" })
       end
     end
   end

--- a/app/helpers/vehicles_helper.rb
+++ b/app/helpers/vehicles_helper.rb
@@ -21,7 +21,7 @@ module VehiclesHelper
   def grouped_vehicles_for_select
     all_vehicles = Vehicle.all.pluck(:vehicle_type, :number, :id)
     Vehicle.vehicle_types.keys.map do |vehicle_type|
-      vehicles = all_vehicles.select { |v| v[0] == vehicle_type }.map { |v| [v[1], v[2]] }
+      vehicles = all_vehicles.select {|v| v[0] == vehicle_type }.map {|v| [v[1], v[2]] }
       [vehicle_type_label(vehicle_type), vehicles]
     end
   end

--- a/app/helpers/vehicles_helper.rb
+++ b/app/helpers/vehicles_helper.rb
@@ -19,8 +19,10 @@ module VehiclesHelper
   end
 
   def grouped_vehicles_for_select
+    all_vehicles = Vehicle.all.pluck(:vehicle_type, :number, :id)
     Vehicle.vehicle_types.keys.map do |vehicle_type|
-      [vehicle_type_label(vehicle_type), Vehicle.where(vehicle_type: vehicle_type).pluck(:number, :id)]
+      vehicles = all_vehicles.select { |v| v[0] == vehicle_type }.map { |v| [v[1], v[2]] }
+      [vehicle_type_label(vehicle_type), vehicles]
     end
   end
 end

--- a/app/helpers/workers_helper.rb
+++ b/app/helpers/workers_helper.rb
@@ -21,7 +21,7 @@ module WorkersHelper
   def grouped_workers_for_select
     all_workers = Worker.all.pluck(:group, :name, :id)
     Worker.groups.keys.map do |group|
-      workers = all_workers.select { |w| w[0] == group }.map { |w| [w[1], w[2]] }
+      workers = all_workers.select {|w| w[0] == group }.map {|w| [w[1], w[2]] }
       [group_label(group), workers]
     end
   end

--- a/app/helpers/workers_helper.rb
+++ b/app/helpers/workers_helper.rb
@@ -19,8 +19,10 @@ module WorkersHelper
   end
 
   def grouped_workers_for_select
+    all_workers = Worker.all.pluck(:group, :name, :id)
     Worker.groups.keys.map do |group|
-      [group_label(group), Worker.where(group: group).pluck(:name, :id)]
+      workers = all_workers.select { |w| w[0] == group }.map { |w| [w[1], w[2]] }
+      [group_label(group), workers]
     end
   end
 end

--- a/app/views/materials/_pc_nav.html.erb
+++ b/app/views/materials/_pc_nav.html.erb
@@ -1,8 +1,12 @@
 <nav class="pc-nav">
   <ul class="header-menus">
-    <%= header_link('資材登録', new_material_path, 'fa-wrench', controller_name == 'materials' && action_name == 'new', {}, "link-dark") %>
-    <%= header_link('資材一覧', materials_path, 'fa-th-list', controller_name == 'materials' && action_name == 'index', {}, "link-dark") %>
-    <%= header_link('作業記録', attendances_path, 'fa-paste', false, {}, "link-dark") %>
-    <%= header_link('ログアウト', destroy_user_session_path, 'fa-sign-out-alt', false, {method: :delete}, "link-dark") %>
+    <%= header_link(label: '資材登録', path: new_material_path, icon: 'fa-wrench',
+                condition: controller_name == 'materials' && action_name == 'new', link_options: {}, link_class: "link-dark") %>
+    <%= header_link(label: '資材一覧', path: materials_path, icon: 'fa-th-list',
+                    condition: controller_name == 'materials' && action_name == 'index', link_options: {}, link_class: "link-dark") %>
+    <%= header_link(label: '作業記録', path: attendances_path, icon: 'fa-paste',
+                    condition: false, link_options: {}, link_class: "link-dark") %>
+    <%= header_link(label: 'ログアウト', path: destroy_user_session_path, icon: 'fa-sign-out-alt',
+                    condition: false, link_options: {method: :delete}, link_class: "link-dark") %>
   </ul>
 </nav>

--- a/app/views/materials/_sp_nav.html.erb
+++ b/app/views/materials/_sp_nav.html.erb
@@ -7,10 +7,14 @@
     </p>
     <nav id="gNav" class="">
       <ul class="gNav-menu">
-        <%= header_link('資材登録', new_material_path, 'fa-wrench', controller_name == 'materials' && action_name == 'new', {}, "link-light") %>
-        <%= header_link('資材一覧', materials_path, 'fa-th-list', controller_name == 'materials' && action_name == 'index', {}, "link-light") %>
-        <%= header_link('作業記録', attendances_path, 'fa-paste', false, {}, "link-light") %>
-        <%= header_link('ログアウト', destroy_user_session_path, 'fa-sign-out-alt', false, {method: :delete}, "link-light") %>
+        <%= header_link(label: '資材登録', path: new_material_path, icon: 'fa-wrench',
+                        condition: controller_name == 'materials' && action_name == 'new', link_options: {}, link_class: "link-dark") %>
+        <%= header_link(label: '資材一覧', path: materials_path, icon: 'fa-th-list',
+                        condition: controller_name == 'materials' && action_name == 'index', link_options: {}, link_class: "link-dark") %>
+        <%= header_link(label: '作業記録', path: attendances_path, icon: 'fa-paste',
+                        condition: false, link_options: {}, link_class: "link-dark") %>
+        <%= header_link(label: 'ログアウト', path: destroy_user_session_path, icon: 'fa-sign-out-alt',
+                        condition: false, link_options: {method: :delete}, link_class: "link-dark") %>
       </ul>
     </nav>
   </div>


### PR DESCRIPTION
## ヘルパーメソッド
それぞれのenumキーに対して個別にデータベースからレコードを取得していたため、クエリの数がenumキーの数だけ発行されていた。 なので、改修後のメソッドでは、まずすべてのレコードを一度に取得し、それをenumキーでグルーピングしています。これにより、データベースへのクエリが1回だけで済むようになり、パフォーマンスが向上しました。